### PR TITLE
Code coverage support

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -2,13 +2,8 @@ module.exports = (grunt) ->
 
   require('time-grunt') grunt
 
-  ###
-  Dynamically load npm tasks
-  ###
+  # Dynamically load npm tasks
   require('jit-grunt') grunt
-
-  grunt.loadNpmTasks('grunt-contrib-coffee')
-  grunt.loadNpmTasks('grunt-mocha-test')
 
   # Actually load this plugin's task(s).
   grunt.loadTasks('tasks')
@@ -38,12 +33,21 @@ module.exports = (grunt) ->
         dest: 'tasks/',
         ext: '.js'
 
+    coffeecov:
+      compile:
+        src: 'src'
+        dest: 'tasks'
+
     mochaTest:
       test:
         options:
-          reporter: 'spec'
+          reporter: 'mocha-phantom-coverage-reporter'
           require: 'coffee-script/register'
         src: ['test/**/*.coffee']
+
+    shell:
+      coveralls:
+        command: 'cat coverage/coverage.lcov | ./node_modules/coveralls/bin/coveralls.js src'
 
     # Before generating any new files, remove any previously-created files.
     clean:
@@ -59,14 +63,20 @@ module.exports = (grunt) ->
         ext: '.html'
 
 
+  grunt.registerTask 'uploadCoverage', ->
+    return grunt.log.ok 'Bypass uploading' unless process.env['TRAVIS'] is 'true'
+
+    grunt.task.run 'shell:coveralls'
+
   grunt.registerTask "default", [
     "watch"
   ]
 
   grunt.registerTask "test", [
-    "coffee"
+    "coffeecov"
     "raml2html"
     "mochaTest"
+    "uploadCoverage"
   ]
 
   return

--- a/package.json
+++ b/package.json
@@ -31,12 +31,15 @@
     "chai": "~2.1.1",
     "coffee-script": "~1.9.1",
     "grunt": "~0.4.5",
+    "grunt-cli": "~0.1.13",
+    "grunt-coffeecov": "^0.1.5",
     "grunt-contrib-coffee": "~0.13.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-mocha-test": "~0.12.7",
-    "grunt-cli": "~0.1.13",
+    "grunt-shell": "^1.1.2",
     "jit-grunt": "~0.9.1",
     "mocha": "~2.2.1",
+    "mocha-phantom-coverage-reporter": "^0.1.0",
     "time-grunt": "~1.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
This PR is incomplete, as 

- Actual tests are started by `grunt raml2html`