### PR TITLE
Fix async race condition by processing all files before calling done.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "time-grunt": "~1.1.0"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "raml2html": "^1.5.0"
   },
   "peerDependencies": {

--- a/src/raml2html.coffee
+++ b/src/raml2html.coffee
@@ -1,8 +1,9 @@
 raml2html = require 'raml2html'
+async = require 'async'
 
 module.exports = (grunt) ->
   grunt.registerMultiTask 'raml2html', 'Compile raml files to html', ->
-    async = @async
+    done = @async()
     {rootObject, use_https, templates} = @options()
     rootObject ?= false
     use_https ?= false
@@ -13,23 +14,24 @@ module.exports = (grunt) ->
     resource ?= false
     item ?= false
 
-    @files.forEach ({src, dest}) ->
+    async.eachSeries @files, ({src, dest}, next) ->
       grunt.log.debug("Compiling #{src} to #{dest}")
 
       [source] = src
 
-      done = async()
       config = raml2html.getDefaultConfig(use_https, main, resource, item);
       raml2html.render source, config, (html) ->
         grunt.file.write dest, html
         grunt.log.writeln("File #{dest.cyan} created.")
-        done()
+        next()
 
       , (error) ->
         grunt.log.error(error)
-        done()
+        next()
 
       grunt.log.debug("Compiled #{src}")
+
+    , done
 
 
     fileCount = @files.length


### PR DESCRIPTION
If there are multiple files to be processed, there is a race condition in asynchronous processing in which the process will sometimes exit before all rendered destination files have been written to disk.  The previous code would erroneously invoke the Grunt task's "done" function as soon as the first file has been written to disk.

This behavior has been observed with Grunt 0.4.5 and Node.js v0.10.36.

The fix is to utilize the `async` package, and use its callback for `async.eachSeries` to invoke the "done" function for the Grunt multi-task.