### PR TITLE
update html2raml and async versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ In this example, the default options are used to do something with whatever. So 
 grunt.initConfig({
   raml2html: {
     all: {
-      options: {},
       files: {
         'dest/api.html': ['api.raml'],
       }
@@ -95,16 +94,15 @@ grunt.initConfig({
 
 #### Custom Template
 
-In this example, using custom template for main content
+Custom templates can be loaded using the following. Both mainTemplate and templatesPath are required in this case. Other templates, such as resource.nunjucks and item.nunjucks are now seen as part of the main template. Therefore they cannot be set individually.
 
 ```js
 grunt.initConfig({
   raml2html: {
     all: {
-      templates: {
-        main: 'template.handlebars',
-        resource: 'resource.handlebars',
-        item: 'item.handlebars'
+      options: {
+        mainTemplate: 'template.nunjucks',
+        templatesPath: './my/custom/path'
       },
       files: {
         'dest/api.html': ['src/github.raml'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-raml2html",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Grunt plugin to compile raml to html",
   "directories": {
     "test": "test"
@@ -40,8 +40,8 @@
     "time-grunt": "~1.2.0"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "raml2html": "^1.6.0"
+    "async": "~1.3.0",
+    "raml2html": "~2.0.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.5"

--- a/src/raml2html.coffee
+++ b/src/raml2html.coffee
@@ -4,35 +4,30 @@ async = require 'async'
 module.exports = (grunt) ->
   grunt.registerMultiTask 'raml2html', 'Compile raml files to html', ->
     done = @async()
-    {rootObject, use_https, templates} = @options()
-    rootObject ?= false
-    use_https ?= false
-    templates ?= false
-
-    {main, resource, item} = templates
-    main ?= false
-    resource ?= false
-    item ?= false
+    {mainTemplate, templatesPath} = @options()
+    mainTemplate ?= false
+    templatesPath ?= false
 
     async.eachSeries @files, ({src, dest}, next) ->
-      grunt.log.debug("Compiling #{src} to #{dest}")
+      grunt.log.debug "Compiling #{src} to #{dest}"
 
       [source] = src
 
-      config = raml2html.getDefaultConfig(use_https, main, resource, item);
-      raml2html.render source, config, (html) ->
+      config = raml2html.getDefaultConfig mainTemplate, templatesPath
+
+      raml2html.render source, config
+      .then (html)->
         grunt.file.write dest, html
-        grunt.log.writeln("File #{dest.cyan} created.")
+        grunt.log.writeln "file #{dest.cyan} created"
         next()
+      .fail (error)->
+        grunt.log.error error
+        done false
 
-      , (error) ->
-        grunt.log.error(error)
-        done(false)
-
-      grunt.log.debug("Compiled #{src}")
+      grunt.log.debug "Compiled #{src}"
 
     , done
 
-
     fileCount = @files.length
-    grunt.log.ok("#{fileCount} #{grunt.util.pluralize(fileCount, 'file/files')} compiled to html.")
+    grunt.log.ok "#{fileCount} #{grunt.util.pluralize fileCount, 'file/files'} compiled to html."
+


### PR DESCRIPTION
This makes grunt-html2raml compatible with the latest version of html2raml, which supports other layouts, and will receive the latest template (which will be in the nunjucks format) when it arrives.